### PR TITLE
chore: release v0.0.1

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,3 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/ocasazza/nix-rust-template/releases/tag/nix-rust-template-web-v0.0.1) - 2025-07-13
+
+### Fixed
+
+- fixes
+
+### Other
+
+- rename the lib
+- better Post
+- more simpler
+- clean
+- release v0.0.1
+- I think its more organized
+- use artifacts in ci
+- stub
+- stub
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION



## 🤖 New release

* `nix-rust-template-client`: 0.0.1
* `nix-rust-template-web`: 0.0.1
* `nix-rust-template-server`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `nix-rust-template-client`

<blockquote>

## [0.0.1](https://github.com/ocasazza/nix-rust-template/releases/tag/nix-rust-template-client-v0.0.1) - 2025-07-13

### Other

- I think its more organized
- use artifacts in ci
- stub
</blockquote>

## `nix-rust-template-web`

<blockquote>

## [0.0.1](https://github.com/ocasazza/nix-rust-template/releases/tag/nix-rust-template-web-v0.0.1) - 2025-07-13

### Fixed

- fixes

### Other

- rename the lib
- better Post
- more simpler
- clean
- release v0.0.1
- I think its more organized
- use artifacts in ci
- stub
- stub
</blockquote>

## `nix-rust-template-server`

<blockquote>

## [0.0.1](https://github.com/ocasazza/nix-rust-template/releases/tag/nix-rust-template-server-v0.0.1) - 2025-07-13

### Other

- I think its more organized
- use artifacts in ci
- stub
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).